### PR TITLE
Use semver for parsing/comparing op versions

### DIFF
--- a/daktari/check.py
+++ b/daktari/check.py
@@ -76,14 +76,14 @@ class Check:
         self,
         application: str,
         installed_version: Optional[VersionInfo],
-        required_version: str,
+        required_version: Optional[str] = None,
         recommended_version: Optional[str] = None,
     ) -> CheckResult:
         if installed_version is None:
             return self.failed(f"{application} is not installed")
 
         try:
-            matches_required = installed_version.match(required_version)
+            matches_required = required_version is None or installed_version.match(required_version)
             matches_recommended = recommended_version is None or installed_version.match(recommended_version)
         except ValueError as err:
             return self.failed(f"Invalid version specification: {err}")

--- a/daktari/checks/java.py
+++ b/daktari/checks/java.py
@@ -64,7 +64,7 @@ def parse_legacy_java_number(version_string: str) -> Optional[int]:
 class JavaVersion(Check):
     name = "java.version"
 
-    def __init__(self, required_version: str, recommended_version: Optional[str] = None):
+    def __init__(self, required_version: Optional[str] = None, recommended_version: Optional[str] = None):
         self.required_version = required_version
         self.recommended_version = recommended_version
 


### PR DESCRIPTION
Fixes a bug where 1.8 was considered a higher version than 1.11 due to `float` being used for specifying/comparing versions. They are now specified using semver expressions in the same way as the Java version check, e.g.:

```
checks = [
    OnePassInstalled(">=1.8.0"),
]
```

(This supports an optional `recommended_version` that warns if it is not met).