### PR TITLE
Disable concurrent releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+concurrency: release
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Prevents any nasty race conditions with the release in the event that a trigger-happy developer like me decides to merge two PRs at once :grin: 