### PR TITLE
Bug fix - yarnrc scope

### DIFF
--- a/daktari/checks/test_yarn.py
+++ b/daktari/checks/test_yarn.py
@@ -52,11 +52,14 @@ class TestYarn(unittest.TestCase):
         nonexistent_scope_1 = YarnNpmScope("glean", npmRegistryServer="http://localhost")
         # Auth token required, none supplied:
         nonexistent_scope_2 = YarnNpmScope("glean", npmRegistryServer=TEST_REGISTRY_SERVER, requireNpmAuthToken=True)
+        # Wrong name
+        nonexistent_scope_3 = YarnNpmScope("walter")
 
         self.assertTrue(yarnrc_contains_scope(yarnrc, existing_scope_1))
         self.assertTrue(yarnrc_contains_scope(yarnrc, existing_scope_2))
         self.assertFalse(yarnrc_contains_scope(yarnrc, nonexistent_scope_1))
         self.assertFalse(yarnrc_contains_scope(yarnrc, nonexistent_scope_2))
+        self.assertFalse(yarnrc_contains_scope(yarnrc, nonexistent_scope_3))
 
 
 if __name__ == "__main__":

--- a/daktari/checks/yarn.py
+++ b/daktari/checks/yarn.py
@@ -64,10 +64,11 @@ def match_scope(template: YarnNpmScope, scope: Dict[str, Any]) -> bool:
 
 def yarnrc_contains_scope(yarnrc: Dict[str, Any], scope: YarnNpmScope) -> bool:
     yarnrc_scopes = yarnrc.get("npmScopes", {})
-    for yarnrc_scope in yarnrc_scopes.values():
-        if match_scope(scope, yarnrc_scope):
-            return True
-    return False
+    yarnrc_scope = yarnrc_scopes.get(scope.name)
+    if yarnrc_scope is None:
+        return False
+
+    return match_scope(scope, yarnrc_scope)
 
 
 class YarnNpmScopeConfigured(Check):


### PR DESCRIPTION
We never actually checked the name before, meaning so long as you had an arbitrary scope set up with the required fields the check would pass. 