### PR TITLE
Improve debug logging for failed commands

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.6.15', 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,10 +5,10 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.6.15', 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/daktari/command_utils.py
+++ b/daktari/command_utils.py
@@ -66,6 +66,7 @@ def get_stdout(command) -> Optional[str]:
     try:
         return run_command(command).stdout
     except Exception:
+        logging.debug("Exception running command", exc_info=True)
         return None
 
 
@@ -73,4 +74,5 @@ def get_stderr(command) -> Optional[str]:
     try:
         return run_command(command).stderr
     except Exception:
+        logging.debug("Exception running command", exc_info=True)
         return None


### PR DESCRIPTION
Was running in `glean-mobile` and couldn't figure out why it thought I didn't have flutter installed. After the change it became clear:

```
INFO:root:Running check flutter.installed
DEBUG:root:Running command 'flutter --version'
DEBUG:root:Exception running command
Traceback (most recent call last):
  File "/home/alyssa/daktari/daktari/command_utils.py", line 67, in get_stdout
    return run_command(command).stdout
  File "/home/alyssa/daktari/daktari/command_utils.py", line 33, in run_command
    command_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, input="", universal_newlines=True
  File "/usr/lib/python3.6/subprocess.py", line 423, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1364, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
PermissionError: [Errno 13] Permission denied: 'flutter'
INFO:root:Flutter version: None
❌ [flutter.installed] Flutter is not installed
┌─💡 Suggestion ────────────────────────────────────────────────┐
│ Install Flutter: https://flutter.dev/docs/get-started/install │
└───────────────────────────────────────────────────────────────┘
```

Also fixed CI by pinning the runner image (and upgraded the `setup-python` action for good measure)