### PR TITLE
Certificate expiry check

### DIFF
--- a/daktari/checks/certs.py
+++ b/daktari/checks/certs.py
@@ -19,7 +19,13 @@ class CertificateIsNotExpired(Check):
     def check(self) -> CheckResult:
         with open(self.certificate_path, "rb") as f:
             cert = crypto.load_certificate(crypto.FILETYPE_PEM, f.read())
-            logging.debug(f"Raw expiry: f{cert.get_notAfter()}")
+            logging.debug(f"Raw expiry: f{cert.get_notAfter()!r}")
+
+            expiry_bytes = cert.get_notAfter()
+            if expiry_bytes is None:
+                return self.passed_with_warning(
+                    f"Unable to determine expiry date of {os.path.basename(self.certificate_path)}"
+                )
 
             expiry = datetime.strptime(cert.get_notAfter().decode(), "%Y%m%d%H%M%SZ")
             if expiry > datetime.now():

--- a/daktari/checks/certs.py
+++ b/daktari/checks/certs.py
@@ -27,7 +27,7 @@ class CertificateIsNotExpired(Check):
                     f"Unable to determine expiry date of {os.path.basename(self.certificate_path)}"
                 )
 
-            expiry = datetime.strptime(cert.get_notAfter().decode(), "%Y%m%d%H%M%SZ")
+            expiry = datetime.strptime(expiry_bytes.decode(), "%Y%m%d%H%M%SZ")
             if expiry > datetime.now():
                 return self.passed(f"{os.path.basename(self.certificate_path)} is not expired")
             else:

--- a/daktari/checks/certs.py
+++ b/daktari/checks/certs.py
@@ -19,7 +19,7 @@ class CertificateIsNotExpired(Check):
     def check(self) -> CheckResult:
         with open(self.certificate_path, "rb") as f:
             cert = crypto.load_certificate(crypto.FILETYPE_PEM, f.read())
-            logging.debug(f"Raw expiry: f{cert.get_notAfter()!r}")
+            logging.debug(f"Raw expiry: {cert.get_notAfter()!r}")
 
             expiry_bytes = cert.get_notAfter()
             if expiry_bytes is None:

--- a/daktari/checks/certs.py
+++ b/daktari/checks/certs.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from datetime import datetime
-from OpenSSL import crypto as c
+from OpenSSL import crypto
 
 from daktari.check import Check, CheckResult
 from daktari.os import OS
@@ -17,8 +17,8 @@ class CertificateIsNotExpired(Check):
         }
 
     def check(self) -> CheckResult:
-        with open(self.certificate_path, "r") as f:
-            cert = c.load_certificate(c.FILETYPE_PEM, f.read())
+        with open(self.certificate_path, "rb") as f:
+            cert = crypto.load_certificate(crypto.FILETYPE_PEM, f.read())
             logging.debug(f"Raw expiry: f{cert.get_notAfter()}")
 
             expiry = datetime.strptime(cert.get_notAfter().decode(), "%Y%m%d%H%M%SZ")

--- a/daktari/checks/certs.py
+++ b/daktari/checks/certs.py
@@ -1,0 +1,28 @@
+import logging
+import os
+from datetime import datetime
+from OpenSSL import crypto as c
+
+from daktari.check import Check, CheckResult
+from daktari.os import OS
+
+
+class CertificateIsNotExpired(Check):
+    name = "certificate.isNotExpired"
+
+    def __init__(self, certificate_path: str):
+        self.certificate_path = certificate_path
+        self.suggestions = {
+            OS.GENERIC: f"Regenerate the certificate at {certificate_path}",
+        }
+
+    def check(self) -> CheckResult:
+        with open(self.certificate_path, "r") as f:
+            cert = c.load_certificate(c.FILETYPE_PEM, f.read())
+            logging.debug(f"Raw expiry: f{cert.get_notAfter()}")
+
+            expiry = datetime.strptime(cert.get_notAfter().decode(), "%Y%m%d%H%M%SZ")
+            if expiry > datetime.now():
+                return self.passed(f"{os.path.basename(self.certificate_path)} is not expired")
+            else:
+                return self.failed(f"{os.path.basename(self.certificate_path)} expired on {expiry}")

--- a/daktari/checks/test_certs.py
+++ b/daktari/checks/test_certs.py
@@ -8,6 +8,14 @@ from daktari.resource_utils import get_resource_path
 
 class TestCertificateIsNotExpired(unittest.TestCase):
     @mock.patch("certs.crypto.load_certificate")
+    def test_passes_with_warning_if_cannot_determine_expiry(self, mock_get_not_after):
+        mock_get_not_after.return_value.get_notAfter.return_value = None
+        check = CertificateIsNotExpired(get_resource_path("mock_cert.pem").__str__())
+        result = check.check()
+        self.assertEqual(result.status, CheckStatus.PASS_WITH_WARNING)
+        self.assertEqual(result.summary, "Unable to determine expiry date of mock_cert.pem")
+
+    @mock.patch("certs.crypto.load_certificate")
     def test_passes_for_valid_cert(self, mock_get_not_after):
         mock_get_not_after.return_value.get_notAfter.return_value = b"20501231235959Z"
         check = CertificateIsNotExpired(get_resource_path("mock_cert.pem").__str__())

--- a/daktari/checks/test_certs.py
+++ b/daktari/checks/test_certs.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest import mock
+
+from daktari.check import CheckStatus
+from daktari.checks.certs import CertificateIsNotExpired
+from daktari.resource_utils import get_resource_path
+
+
+class TestCertificateIsNotExpired(unittest.TestCase):
+    @mock.patch("certs.crypto.load_certificate")
+    def test_passes_for_valid_cert(self, mock_get_not_after):
+        mock_get_not_after.return_value.get_notAfter.return_value = b"20501231235959Z"
+        check = CertificateIsNotExpired(get_resource_path("mock_cert.pem").__str__())
+        result = check.check()
+        self.assertEqual(result.status, CheckStatus.PASS)
+        self.assertEqual(result.summary, "mock_cert.pem is not expired")
+
+    @mock.patch("certs.crypto.load_certificate")
+    def test_fails_for_expired_cert(self, mock_get_not_after):
+        mock_get_not_after.return_value.get_notAfter.return_value = b"20201231235959Z"
+        check = CertificateIsNotExpired(get_resource_path("mock_cert.pem").__str__())
+        result = check.check()
+        self.assertEqual(result.status, CheckStatus.FAIL)
+        self.assertEqual(result.summary, "mock_cert.pem expired on 2020-12-31 23:59:59")

--- a/daktari/checks/test_certs.py
+++ b/daktari/checks/test_certs.py
@@ -7,7 +7,7 @@ from daktari.resource_utils import get_resource_path
 
 
 class TestCertificateIsNotExpired(unittest.TestCase):
-    @mock.patch("certs.crypto.load_certificate")
+    @mock.patch("daktari.checks.certs.crypto.load_certificate")
     def test_passes_with_warning_if_cannot_determine_expiry(self, mock_get_not_after):
         mock_get_not_after.return_value.get_notAfter.return_value = None
         check = CertificateIsNotExpired(get_resource_path("mock_cert.pem").__str__())
@@ -15,7 +15,7 @@ class TestCertificateIsNotExpired(unittest.TestCase):
         self.assertEqual(result.status, CheckStatus.PASS_WITH_WARNING)
         self.assertEqual(result.summary, "Unable to determine expiry date of mock_cert.pem")
 
-    @mock.patch("certs.crypto.load_certificate")
+    @mock.patch("daktari.checks.certs.crypto.load_certificate")
     def test_passes_for_valid_cert(self, mock_get_not_after):
         mock_get_not_after.return_value.get_notAfter.return_value = b"20501231235959Z"
         check = CertificateIsNotExpired(get_resource_path("mock_cert.pem").__str__())
@@ -23,7 +23,7 @@ class TestCertificateIsNotExpired(unittest.TestCase):
         self.assertEqual(result.status, CheckStatus.PASS)
         self.assertEqual(result.summary, "mock_cert.pem is not expired")
 
-    @mock.patch("certs.crypto.load_certificate")
+    @mock.patch("daktari.checks.certs.crypto.load_certificate")
     def test_fails_for_expired_cert(self, mock_get_not_after):
         mock_get_not_after.return_value.get_notAfter.return_value = b"20201231235959Z"
         check = CertificateIsNotExpired(get_resource_path("mock_cert.pem").__str__())

--- a/daktari/resource_utils.py
+++ b/daktari/resource_utils.py
@@ -1,6 +1,11 @@
 from importlib_resources import files
+from importlib_resources.abc import Traversable
 
 
 def get_resource(name: str) -> str:
     """Load a textual resource file."""
-    return files("daktari.resources").joinpath(name).read_text(encoding="utf-8")
+    return get_resource_path(name).read_text(encoding="utf-8")
+
+
+def get_resource_path(name: str) -> Traversable:
+    return files("daktari.resources").joinpath(name)

--- a/daktari/resources/mock_cert.pem
+++ b/daktari/resources/mock_cert.pem
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+NOTreallyAcertificateTHOUGH
+-----END CERTIFICATE-----

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pyobjc-core==8.1; sys_platform == 'darwin'
 pyobjc-framework-Cocoa==8.1; sys_platform == 'darwin'
 requests-unixsocket==0.2.0
 dpath==2.0.5
+pyOpenSSL==23.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pyobjc-framework-Cocoa==8.1; sys_platform == 'darwin'
 requests-unixsocket==0.2.0
 dpath==2.0.5
 pyOpenSSL==23.0.0
+types-pyOpenSSL==23.0.0


### PR DESCRIPTION
Towards: https://glean-co.slack.com/archives/CB1L4EYEQ/p1676033427007009

Implemented as a generic check because it might be helpful in general. For Glean, I'll subclass this so we can give a more specific message and make it depend on the prior check (that the files exist). The failure looks like the following:

![image](https://user-images.githubusercontent.com/57534485/218128814-413e7b56-89b0-4bd6-8e54-90c685426a5c.png)
