### PR TITLE
[EE-358] Fail fast

### DIFF
--- a/daktari/__main__.py
+++ b/daktari/__main__.py
@@ -30,7 +30,7 @@ def main() -> int:
     os.chdir(args.config_path.parent.absolute())
     print_config_messages(config, args)
 
-    all_passed = run_checks(config.checks, args.quiet_mode or config.quiet_mode)
+    all_passed = run_checks(config.checks, args.quiet_mode or config.quiet_mode, args.fail_fast)
     print("")
     return 0 if all_passed else 1
 

--- a/daktari/__main__.py
+++ b/daktari/__main__.py
@@ -46,7 +46,7 @@ def print_config_messages(config: Config, args):
             for check in config.ignored_checks:
                 print(f"[{check.name}]")
             print("")
-        else:
+        elif not args.quiet_mode:
             print(f"ⓘ  {ignored_count} check(s) have been marked as ignored. Run with --show-ignored to list them.\n")
 
 

--- a/daktari/check_runner.py
+++ b/daktari/check_runner.py
@@ -24,10 +24,13 @@ class CheckRunner:
     def run(self) -> bool:
         for idx, check in enumerate(sort_checks(self.checks)):
             self.try_run_check(idx, check)
-            if self.fail_fast and not self.all_passed:
+            if self.early_exit():
                 break
 
         return self.all_passed
+
+    def early_exit(self) -> bool:
+        return self.fail_fast and not self.all_passed
 
     def try_run_check(self, idx: int, check: Check):
         dependencies_met = all([dependency.name in self.checks_passed for dependency in check.depends_on])
@@ -44,7 +47,7 @@ class CheckRunner:
         else:
             self.all_passed = False
 
-        print_check_result(result, self.quiet_mode, idx, len(self.checks))
+        print_check_result(result, self.early_exit(), self.quiet_mode, idx, len(self.checks))
 
     def run_check_in_try(self, check: Check) -> CheckResult:
         try:

--- a/daktari/check_runner.py
+++ b/daktari/check_runner.py
@@ -9,20 +9,24 @@ from daktari.os import detect_os
 from daktari.result_printer import print_check_result
 
 
-def run_checks(checks: List[Check], hide_passing_checks: bool) -> bool:
-    return CheckRunner(checks, hide_passing_checks).run()
+def run_checks(checks: List[Check], quiet_mode: bool, fail_fast: bool) -> bool:
+    return CheckRunner(checks, quiet_mode, fail_fast).run()
 
 
 class CheckRunner:
-    def __init__(self, checks: List[Check], quiet_mode: bool):
+    def __init__(self, checks: List[Check], quiet_mode: bool, fail_fast: bool):
         self.checks = [check for check in checks if check.run_on is None or check.run_on == detect_os()]
         self.all_passed = True
         self.checks_passed: Set[str] = set()
         self.quiet_mode = quiet_mode
+        self.fail_fast = fail_fast
 
     def run(self) -> bool:
         for idx, check in enumerate(sort_checks(self.checks)):
             self.try_run_check(idx, check)
+            if self.fail_fast and not self.all_passed:
+                break
+
         return self.all_passed
 
     def try_run_check(self, idx: int, check: Check):

--- a/daktari/options.py
+++ b/daktari/options.py
@@ -24,6 +24,9 @@ argument_parser.add_argument(
     "-q", "--quiet", action="store_true", dest="quiet_mode", help="only show failed checks and overall progress"
 )
 argument_parser.add_argument(
+    "-f", "--fail-fast", action="store_true", dest="fail_fast", help="stop running checks after the first failure"
+)
+argument_parser.add_argument(
     "-c",
     "--config",
     default=".daktari.py",

--- a/daktari/result_printer.py
+++ b/daktari/result_printer.py
@@ -54,7 +54,7 @@ def print_suggestion_text(text: str):
     print("└" + "─" * (max_width + 2) + "┘")
 
 
-def print_check_result(result: CheckResult, quiet_mode: bool, idx: int, total_checks: int):
+def print_check_result(result: CheckResult, early_exit: bool, quiet_mode: bool, idx: int, total_checks: int):
     this_os = detect_os()
     status_symbol = check_status_symbol(result.status)
     colour = check_status_colour(result.status)
@@ -68,18 +68,21 @@ def print_check_result(result: CheckResult, quiet_mode: bool, idx: int, total_ch
             print("")
 
     if quiet_mode:
-        print_progress_bar(idx + 1, total_checks)
+        print_progress_bar(early_exit, idx + 1, total_checks)
+    elif early_exit:
+        print("ⓘ  Exited early due to --fail-fast flag")
 
 
-def print_progress_bar(current: int, total: int):
-    end_char = "\r" if current < total else "\n"
-    print(progress_bar(current, total), end=end_char)
+def print_progress_bar(early_exit: bool, current: int, total: int):
+    end_char = "\n" if current == total or early_exit else "\r"
+    print(progress_bar(current, total, early_exit), end=end_char)
 
 
-def progress_bar(current: int, total: int) -> str:
+def progress_bar(current: int, total: int, early_exit: bool) -> str:
     fraction = current / total
 
-    arrow = int(fraction * 25 - 1) * "-" + ">"
+    arrow_head = "x" if early_exit else ">"
+    arrow = int(fraction * 25 - 1) * "-" + arrow_head
     padding = int(25 - len(arrow)) * " "
 
     return f"Progress: [{arrow}{padding}] {int(fraction*100)}%  ({current}/{total})"

--- a/daktari/test_check_factory.py
+++ b/daktari/test_check_factory.py
@@ -2,14 +2,24 @@ from daktari.check import Check, CheckResult
 
 
 class DummyCheck(Check):
-    def __init__(self, name: str = "check.name", depends_on=None):
+    def __init__(self, name: str = "check.name", depends_on=None, succeed: bool = True):
         if depends_on is None:
             depends_on = []
         self.name = name
         self.depends_on = depends_on
+        self.was_run = False
+        self.succeed = succeed
 
     def check(self) -> CheckResult:
-        return self.passed("no check")
+        self.was_run = True
+        return self.verify(self.succeed, "dummy check")
+
+
+class ExplodingCheck(Check):
+    name = "exploding.check"
+
+    def check(self) -> CheckResult:
+        raise Exception("boom")
 
 
 class DummyCheck2(Check):

--- a/daktari/test_check_runner.py
+++ b/daktari/test_check_runner.py
@@ -71,7 +71,7 @@ class TestCheckRunner(unittest.TestCase):
             checks = [DummyCheck("check.one", succeed=True)]
             result = run_checks(checks, quiet_mode=True, fail_fast=False)
             self.assertTrue(result)
-            self.assertNotIn(f"✅", fake_out.getvalue())
+            self.assertNotIn("✅", fake_out.getvalue())
 
     def test_outputs_failure_in_quiet_mode(self):
         with patch("sys.stdout", new=StringIO()) as fake_out:

--- a/daktari/test_check_runner.py
+++ b/daktari/test_check_runner.py
@@ -1,0 +1,81 @@
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+from colors import red, yellow, green
+
+from daktari.check_runner import run_checks
+from daktari.test_check_factory import DummyCheck, ExplodingCheck
+
+
+class TestCheckRunner(unittest.TestCase):
+    def test_status_all_passing(self):
+        checks = [DummyCheck("check.one", succeed=True), DummyCheck("check.two", succeed=True)]
+        result = run_checks(checks, quiet_mode=True, fail_fast=False)
+        self.assertTrue(result)
+
+    def test_runs_all_and_returns_failure_if_check_fails(self):
+        final_check = DummyCheck("check.three", succeed=True)
+        checks = [DummyCheck("check.one", succeed=True), DummyCheck("check.two", succeed=False), final_check]
+        result = run_checks(checks, quiet_mode=True, fail_fast=False)
+        self.assertFalse(result)
+        self.assertTrue(final_check.was_run)
+
+    def test_aborts_and_returns_failure_if_check_fails_and_fail_fast(self):
+        final_check = DummyCheck("check.three", succeed=True)
+        checks = [DummyCheck("check.one", succeed=True), DummyCheck("check.two", succeed=False), final_check]
+        result = run_checks(checks, quiet_mode=True, fail_fast=True)
+        self.assertFalse(result)
+        self.assertFalse(final_check.was_run)
+
+    def test_copes_with_unhandled_errors_and_runs_later_checks(self):
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            final_check = DummyCheck("check.three", succeed=True)
+            checks = [ExplodingCheck(), final_check]
+            result = run_checks(checks, quiet_mode=True, fail_fast=False)
+            self.assertFalse(result)
+            self.assertTrue(final_check.was_run)
+            self.assertIn(f"💥 [{red('exploding.check')}] Check failed with unhandled Exception", fake_out.getvalue())
+
+    def test_skips_dependents_on_failure(self):
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            final_check = DummyCheck("dependent.check", depends_on=[ExplodingCheck], succeed=True)
+            checks = [ExplodingCheck(), final_check]
+            result = run_checks(checks, quiet_mode=True, fail_fast=False)
+            self.assertFalse(result)
+            self.assertFalse(final_check.was_run)
+            self.assertIn(f"⚠️  [{yellow('dependent.check')}] skipped due to previous failures", fake_out.getvalue())
+
+    def test_skips_missing_dependencies(self):
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            missing_check = DummyCheck("check.one")
+            final_check = DummyCheck("dependent.check", depends_on=[missing_check])
+            checks = [final_check]
+            result = run_checks(checks, quiet_mode=True, fail_fast=False)
+            self.assertTrue(result)
+            self.assertFalse(final_check.was_run)
+            self.assertIn(
+                f"⚠️  [{yellow('dependent.check')}] skipped due to missing dependent checks: check.one",
+                fake_out.getvalue(),
+            )
+
+    def test_outputs_success(self):
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            checks = [DummyCheck("check.one", succeed=True)]
+            result = run_checks(checks, quiet_mode=False, fail_fast=False)
+            self.assertTrue(result)
+            self.assertIn(f"✅ [{green('check.one')}] dummy check", fake_out.getvalue())
+
+    def test_suppresses_success_in_quiet_mode(self):
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            checks = [DummyCheck("check.one", succeed=True)]
+            result = run_checks(checks, quiet_mode=True, fail_fast=False)
+            self.assertTrue(result)
+            self.assertNotIn(f"✅", fake_out.getvalue())
+
+    def test_outputs_failure_in_quiet_mode(self):
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            checks = [DummyCheck("check.one", succeed=False)]
+            result = run_checks(checks, quiet_mode=True, fail_fast=False)
+            self.assertFalse(result)
+            self.assertIn(f"❌ [{red('check.one')}] dummy check", fake_out.getvalue())

--- a/daktari/test_result_printer.py
+++ b/daktari/test_result_printer.py
@@ -5,10 +5,11 @@ from daktari.result_printer import progress_bar
 
 class TestResultPrinter(unittest.TestCase):
     def test_progress_bar(self):
-        self.assertEqual(progress_bar(0, 50), "Progress: [>                        ] 0%  (0/50)")
-        self.assertEqual(progress_bar(5, 50), "Progress: [->                       ] 10%  (5/50)")
-        self.assertEqual(progress_bar(10, 40), "Progress: [----->                   ] 25%  (10/40)")
-        self.assertEqual(progress_bar(20, 40), "Progress: [----------->             ] 50%  (20/40)")
-        self.assertEqual(progress_bar(20, 37), "Progress: [------------>            ] 54%  (20/37)")
-        self.assertEqual(progress_bar(30, 40), "Progress: [----------------->       ] 75%  (30/40)")
-        self.assertEqual(progress_bar(40, 40), "Progress: [------------------------>] 100%  (40/40)")
+        self.assertEqual(progress_bar(0, 50, False), "Progress: [>                        ] 0%  (0/50)")
+        self.assertEqual(progress_bar(5, 50, False), "Progress: [->                       ] 10%  (5/50)")
+        self.assertEqual(progress_bar(10, 40, False), "Progress: [----->                   ] 25%  (10/40)")
+        self.assertEqual(progress_bar(20, 40, False), "Progress: [----------->             ] 50%  (20/40)")
+        self.assertEqual(progress_bar(20, 37, False), "Progress: [------------>            ] 54%  (20/37)")
+        self.assertEqual(progress_bar(30, 40, False), "Progress: [----------------->       ] 75%  (30/40)")
+        self.assertEqual(progress_bar(40, 40, False), "Progress: [------------------------>] 100%  (40/40)")
+        self.assertEqual(progress_bar(20, 40, True), "Progress: [-----------x             ] 50%  (20/40)")


### PR DESCRIPTION
Adds a `-f` / `--fail-fast` flag that tells daktari to exit on the first failure it encounters. Combined with `-q`, this makes for a much less overwhelming experience on e.g. setting up Glean for the first time:

![image](https://github.com/glean-notes/daktari/assets/57534485/4f957426-8907-480f-b977-e20e21de4df5)

In non-quiet mode:

![image](https://github.com/glean-notes/daktari/assets/57534485/ec92dd51-1c20-445b-b5d6-c9675948c9ec)
