### PR TITLE
Add Python version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ venv: venv/touchfile
 
 venv/touchfile: requirements.txt
 	python3 -m venv venv
-	. venv/bin/activate; pip install -Ur requirements.txt; pip install -Ur requirements-dev.txt
+	. venv/bin/activate; python3 -m pip install -Ur requirements.txt; python3 -m pip install -Ur requirements-dev.txt
 	touch venv/touchfile
 
 test: venv

--- a/daktari/config.py
+++ b/daktari/config.py
@@ -111,7 +111,7 @@ def is_python_version_on_path() -> bool:
     path = (os.getenv("PATH") or "").lower()
     try:
         python3_version_raw = run_command(["python3", "--version"]).stdout.rstrip("\n")
-        python3_version = re.search("3\\.\\d+\\.\\d+", python3_version_raw)
+        python3_version = re.search(r"3\.\d+\.\d+", python3_version_raw)
         if python3_version:
             python3_version_minor = ".".join(python3_version.group().split(".")[0:2])
         else:
@@ -130,7 +130,7 @@ def is_python_version_on_path() -> bool:
             return False
     else:
         logging.debug("Python 3 does not appear to be on your PATH")
-        logging.debug("Assuming Daktari is install elsewhere in a non-versioned location")
+        logging.debug("Assuming Python is installed elsewhere in a non-versioned location")
         return True
 
 


### PR DESCRIPTION
Hilariously I've been able to test this locally as `python` points to 3.10 but `python3` points to 3.11.

When I run it by changing the python version command to `python` (instead of `python3`) I get this:
```
 PYTHONPATH=../daktari python3 -m daktari                                                                                                                                                              (dev/default)

⚠️  A Python version was detected on your PATH. However the version on your PATH does not match the current version of Python 3 installed. It is possible Daktari is/will be installed under a directory not on your PATH. You may need to update your PATH to use the currently install Python version. E.g. /Users/username/Library/Python/3.11/bin
   ________                    ____             __            
  / ____/ /__  ____ _____     / __ \____  _____/ /_____  _____
 / / __/ / _ \/ __ `/ __ \   / / / / __ \/ ___/ __/ __ \/ ___/
/ /_/ / /  __/ /_/ / / / /  / /_/ / /_/ / /__/ /_/ /_/ / /    
\____/_/\___/\__,_/_/ /_/  /_____/\____/\___/\__/\____/_/   
```

I've also tweaked the pip upgrade command to specify python3 explicitly. I think this should be fine as everyone should have this? 