### PR TITLE
Test Yarn Token to see if it can communicate with GitHub

### DIFF
--- a/daktari/checks/test_yarn.py
+++ b/daktari/checks/test_yarn.py
@@ -3,7 +3,7 @@ from unittest import mock
 import responses
 
 from daktari.check import CheckStatus
-from daktari.checks.yarn import YarnNpmScope, match_scope, yarnrc_contains_scope, YarnNmpGithubTokenValid
+from daktari.checks.yarn import YarnNpmScope, match_scope, yarnrc_contains_scope, YarnNpmGithubTokenValid
 
 TEST_SCOPE_NAME = "scope"
 TEST_REGISTRY_SERVER = "https://registry-server.glean.co"
@@ -74,11 +74,11 @@ class TestYarn(unittest.TestCase):
     def test_returns_expected_result_based_on_http_status(self, mock_get_yarnrc_token_for_scope):
         mock_get_yarnrc_token_for_scope.return_value = "mock-token"
         responses.add(method="GET", url="https://api.github.com/orgs/mock-org/packages?package_type=npm", status=401)
-        result = YarnNmpGithubTokenValid("mock-org", "mock-token").check()
+        result = YarnNpmGithubTokenValid("mock-org", "mock-token").check()
         self.assertEqual(result.status, CheckStatus.FAIL)
 
         responses.add(method="GET", url="https://api.github.com/orgs/mock-org/packages?package_type=npm", status=200)
-        result = YarnNmpGithubTokenValid("mock-org", "mock-token").check()
+        result = YarnNpmGithubTokenValid("mock-org", "mock-token").check()
         self.assertEqual(result.status, CheckStatus.PASS)
 
 

--- a/daktari/checks/test_yarn.py
+++ b/daktari/checks/test_yarn.py
@@ -1,6 +1,9 @@
 import unittest
+from unittest import mock
+import responses
 
-from daktari.checks.yarn import YarnNpmScope, match_scope, yarnrc_contains_scope
+from daktari.check import CheckStatus
+from daktari.checks.yarn import YarnNpmScope, match_scope, yarnrc_contains_scope, YarnNmpGithubTokenValid
 
 TEST_SCOPE_NAME = "scope"
 TEST_REGISTRY_SERVER = "https://registry-server.glean.co"
@@ -65,6 +68,18 @@ class TestYarn(unittest.TestCase):
         self.assertFalse(yarnrc_contains_scope(yarnrc, nonexistent_scope_1))
         self.assertFalse(yarnrc_contains_scope(yarnrc, nonexistent_scope_2))
         self.assertFalse(yarnrc_contains_scope(yarnrc, nonexistent_scope_3))
+
+    @responses.activate
+    @mock.patch("daktari.checks.yarn.get_yarnrc_token_for_scope")
+    def test_returns_expected_result_based_on_http_status(self, mock_get_yarnrc_token_for_scope):
+        mock_get_yarnrc_token_for_scope.return_value = "mock-token"
+        responses.add(method="GET", url="https://api.github.com/orgs/mock-org/packages?package_type=npm", status=401)
+        result = YarnNmpGithubTokenValid("mock-org", "mock-token").check()
+        self.assertEqual(result.status, CheckStatus.FAIL)
+
+        responses.add(method="GET", url="https://api.github.com/orgs/mock-org/packages?package_type=npm", status=200)
+        result = YarnNmpGithubTokenValid("mock-org", "mock-token").check()
+        self.assertEqual(result.status, CheckStatus.PASS)
 
 
 if __name__ == "__main__":

--- a/daktari/checks/yarn.py
+++ b/daktari/checks/yarn.py
@@ -99,7 +99,7 @@ class YarnNpmScopeConfigured(Check):
         return self.passed(f"Scope {self.scope.name} configured in yarnrc")
 
 
-class YarnNmpGithubTokenValid(Check):
+class YarnNpmGithubTokenValid(Check):
     name = "yarn.npmGithubTokenValid"
     depends_on = [YarnNpmScopeConfigured]
 
@@ -132,7 +132,7 @@ class YarnNmpGithubTokenValid(Check):
 def get_yarnrc_contents() -> dict:
     yarnrc_path = get_yarnrc_path()
     if not file_exists(yarnrc_path):
-        raise Exception("~/.yarnrc.yml does not exist")
+        raise Exception(f"{yarnrc_path} does not exist")
 
     try:
         with open(yarnrc_path, "rb") as yarnrc_file:

--- a/daktari/checks/yarn.py
+++ b/daktari/checks/yarn.py
@@ -109,7 +109,7 @@ class YarnNmpGithubTokenValid(Check):
         self.suggestions = {
             OS.GENERIC: "Please check the token was copied correctly from GitHub."
             " Ensure the token hasn't expired, or has been revoked."
-            " Also ensure it has the correct permissions to read packages."
+            " Also, ensure it has the correct permissions to read packages."
         }
 
     def check(self) -> CheckResult:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black~=23.7.0
 flake8~=6.0.0
 mypy~=1.4.1
+types-requests==2.31.0.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 black~=23.7.0
 flake8~=6.0.0
 mypy~=1.4.1
-types-requests==2.31.0.2
+types-requests~=2.31.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ types-dataclasses==0.1.5; python_version < '3.7'
 packaging==20.9
 setuptools==68.0.0
 requests==2.31.0
+responses==0.23.2
 semver==3.0.1
 python-hosts==1.0.3
 tabulate==0.9.0


### PR DESCRIPTION
Copied from JIRA: We have this existing check in Daktari:

```
    YarnNpmScopeConfigured(
        YarnNpmScope(
            name="glean-notes",
            npmPublishRegistry="https://npm.pkg.github.com",
            npmRegistryServer="https://npm.pkg.github.com",
            npmAlwaysAuth=True,
            requireNpmAuthToken=True,
        ),
        tokenInstructions="""To generate the TOKEN, visit https://github.com/settings/tokens. Select 'Generate new token',
pick an appropriate expiration, select the 'write:packages' and 'delete:packages' scopes, and
press 'Generate token' button. Copy the token from the following page.""",
    ),
```

It’s good for first-time setup, but after that it becomes useless. All it does is grep .yarnrc.yaml to ensure it has the right shape - it doesn’t actually check that the token is valid. This means that if the token expires or is accidentally removed in GitHub for some reason, you’re left with a broken yarn install and no advice in Daktari to say what’s wrong.


This adds a check which uses your yarnrc token to call the GitHub NPM Packages API - this will return an error if there's an issue with your token. 

❌ [yarn.npmGithubTokenValid] Github Yarn token is not valid: {"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}
┌─💡 Suggestion ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  Please check the token was copied correctly from GitHub. Ensure the token hasn't expired, or has been revoked. Also, ensure it has the correct permissions to read packages.
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘


Otherwise, it's a nice shiny 200! 

✅ [yarn.npmGithubTokenValid] Github Yarn token is valid
