### PR TITLE
Try to prevent requests vs urllib3 clash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ requests-unixsocket==0.3.0
 dpath==2.1.6
 pyOpenSSL==23.2.0
 types-pyOpenSSL==23.2.0.2
+urllib3<1.27 # pin lower than 2 because of incompatibility with requests lib: https://github.com/psf/requests/issues/6432


### PR DESCRIPTION
The IntelliJ install check blows up for me if I used daktari with a fresh venv. It's fine for my local install - the difference is that currently a venv gets `urlib3` on version 2.x. That major version is incompatible with the `requests` library - there's an [open issue](https://github.com/psf/requests/issues/6432) about it. 

Since we depend on requests, enforce the lower version of urllib3 to avoid this :pray: 

```
DEBUG:root:Exception running check intellij.installed
Traceback (most recent call last):
  File "/home/alyssa/.asdf/installs/daktari/0.0.121/venv/lib/python3.8/site-packages/daktari/check_runner.py", line 54, in run_check_in_try
    return check.check()
  File "/home/alyssa/.asdf/installs/daktari/0.0.121/venv/lib/python3.8/site-packages/daktari/checks/intellij_idea.py", line 121, in check
    intellij_version = get_intellij_idea_version()
  File "/home/alyssa/.asdf/installs/daktari/0.0.121/venv/lib/python3.8/site-packages/daktari/checks/intellij_idea.py", line 106, in get_intellij_idea_version
    return get_intellij_idea_version_snap() or get_intellij_idea_version_tarball()
  File "/home/alyssa/.asdf/installs/daktari/0.0.121/venv/lib/python3.8/site-packages/daktari/checks/intellij_idea.py", line 62, in get_intellij_idea_version_snap
    snaps_req = session.get(
  File "/home/alyssa/.asdf/installs/daktari/0.0.121/venv/lib/python3.8/site-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
  File "/home/alyssa/.asdf/installs/daktari/0.0.121/venv/lib/python3.8/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/alyssa/.asdf/installs/daktari/0.0.121/venv/lib/python3.8/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/home/alyssa/.asdf/installs/daktari/0.0.121/venv/lib/python3.8/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
  File "/home/alyssa/.asdf/installs/daktari/0.0.121/venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 790, in urlopen
    response = self._make_request(
  File "/home/alyssa/.asdf/installs/daktari/0.0.121/venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 496, in _make_request
    conn.request(
TypeError: request() got an unexpected keyword argument 'chunked'
💥 [intellij.installed] Check failed with unhandled TypeError
```