### PR TITLE
dependabot accidentally bumped urllib3, this undoes it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ dpath==2.1.6
 pyOpenSSL==23.2.0
 types-pyOpenSSL==23.2.0.2
 pyclip==0.7.0
-urllib3<2.1 # pin lower than 2 because of incompatibility with requests lib: https://github.com/psf/requests/issues/6432
+urllib3<1.27 # pin lower than 2 because of incompatibility with requests lib: https://github.com/psf/requests/issues/6432


### PR DESCRIPTION
Symptom is:
```
INFO:root:Running check intellij.installed
DEBUG:root:Exception running check intellij.installed
Traceback (most recent call last):
  File "/home/matt/.asdf/installs/daktari/0.0.131/venv/lib/python3.10/site-packages/daktari/check_runner.py", line 50, in run_check_in_try
    return check.check()
  File "/home/matt/.asdf/installs/daktari/0.0.131/venv/lib/python3.10/site-packages/daktari/checks/intellij_idea.py", line 121, in check
    intellij_version = get_intellij_idea_version()
  File "/home/matt/.asdf/installs/daktari/0.0.131/venv/lib/python3.10/site-packages/daktari/checks/intellij_idea.py", line 106, in get_intellij_idea_version
    return get_intellij_idea_version_snap() or get_intellij_idea_version_tarball()
  File "/home/matt/.asdf/installs/daktari/0.0.131/venv/lib/python3.10/site-packages/daktari/checks/intellij_idea.py", line 62, in get_intellij_idea_version_snap
    snaps_req = session.get(
  File "/home/matt/.asdf/installs/daktari/0.0.131/venv/lib/python3.10/site-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
  File "/home/matt/.asdf/installs/daktari/0.0.131/venv/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/matt/.asdf/installs/daktari/0.0.131/venv/lib/python3.10/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/home/matt/.asdf/installs/daktari/0.0.131/venv/lib/python3.10/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
  File "/home/matt/.asdf/installs/daktari/0.0.131/venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 790, in urlopen
    response = self._make_request(
  File "/home/matt/.asdf/installs/daktari/0.0.131/venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 496, in _make_request
    conn.request(
TypeError: HTTPConnection.request() got an unexpected keyword argument 'chunked'
💥 [intellij.installed] Check failed with unhandled TypeError
```