### PR TITLE
Check version is not None (or other non-string values) when looking at IJ version via snap

### DIFF
--- a/daktari/checks/intellij_idea.py
+++ b/daktari/checks/intellij_idea.py
@@ -66,7 +66,8 @@ def get_intellij_idea_version_snap() -> Optional[VersionInfo]:
     logging.debug(f"response from snapd: {snaps_info}")
     version_str = dpath.util.get(snaps_info, "/result/0/version", default=None)
     logging.debug(f"raw snapd version: {version_str}")
-
+    if not isinstance(version_str, str):
+        return None
     version_str = sanitise_version_string(version_str)
 
     version = try_parse_semver(version_str)


### PR DESCRIPTION
Avoid an error if Intellij not installed on Linux:

```
INFO:root:Running check intellij.installed
DEBUG:urllib3.connectionpool:http://localhost:None "GET /v2/snaps?snaps=intellij-idea-ultimate,intellij-idea-community HTTP/1.1" 200 79
DEBUG:root:response from snapd: {'type': 'sync', 'status-code': 200, 'status': 'OK', 'result': [], 'sources': ['local']}
DEBUG:root:raw snapd version: None
DEBUG:root:Exception running check intellij.installed
Traceback (most recent call last):
  File "/home/matt/.asdf/installs/daktari/0.0.135/venv/lib/python3.10/site-packages/daktari/check_runner.py", line 50, in run_check_in_try
    return check.check()
  File "/home/matt/.asdf/installs/daktari/0.0.135/venv/lib/python3.10/site-packages/daktari/checks/intellij_idea.py", line 121, in check
    intellij_version = get_intellij_idea_version()
  File "/home/matt/.asdf/installs/daktari/0.0.135/venv/lib/python3.10/site-packages/daktari/checks/intellij_idea.py", line 106, in get_intellij_idea_version
    return get_intellij_idea_version_snap() or get_intellij_idea_version_tarball()
  File "/home/matt/.asdf/installs/daktari/0.0.135/venv/lib/python3.10/site-packages/daktari/checks/intellij_idea.py", line 70, in get_intellij_idea_version_snap
    version_str = sanitise_version_string(version_str)
  File "/home/matt/.asdf/installs/daktari/0.0.135/venv/lib/python3.10/site-packages/daktari/version_utils.py", line 31, in sanitise_version_string
    return version_str + ".0" if version_str.count(".") == 1 else version_str
AttributeError: 'NoneType' object has no attribute 'count'
💥 [intellij.installed] Check failed with unhandled AttributeError
```