### PR TITLE
Pin `urllib3` in dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,8 @@ updates:
       - 'dependencies'
   - package-ecosystem: 'pip'
     directory: '/'
+    ignore:
+      - dependency-name: 'urllib3' # Due to compatibility issues with 2.x: https://github.com/psf/requests/issues/6432
     schedule:
       interval: 'weekly'
     labels:


### PR DESCRIPTION
See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore