### PR TITLE
remove -u from nvm check

### DIFF
--- a/daktari/checks/nodejs.py
+++ b/daktari/checks/nodejs.py
@@ -16,7 +16,7 @@ def get_nodejs_version() -> Optional[VersionInfo]:
 
 
 def run_nvm(nvm_args: List[str]):
-    return run_command(["sh", "-u", "-c", '. "$NVM_DIR/nvm.sh"; nvm "$@"', "--", *nvm_args])
+    return run_command(["sh", "-c", '. "$NVM_DIR/nvm.sh"; nvm "$@"', "--", *nvm_args])
 
 
 def can_run_nvm() -> bool:


### PR DESCRIPTION
`-u` causes bash to be extra picky about unset variables, and when invoking bash from Python, it seems that `$_` is unset, so it blows up:

```
NVM_SCRIPT_SOURCE="$_"

Stderr = --: 14: /home/matt/.nvm/nvm.sh: _: parameter not set
```

(Behaviour is presumably different with zsh).