### PR TITLE
add get_tool_version utility

### DIFF
--- a/daktari/asdf.py
+++ b/daktari/asdf.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+def get_tool_version_from_string(tool: str, file_content: str) -> Optional[str]:
+    lines = file_content.split("\n")
+    for line in lines:
+        clean_line = line.split("#")[0].strip()
+        if clean_line.startswith(tool + " "):
+            return clean_line.split()[1]
+    return None
+
+def get_tool_versione(tool: str) -> Optional[str]:
+    with open('.tool-versions', 'r') as f:
+        file_content = f.read()
+    return get_tool_version_from_string(tool, file_content)

--- a/daktari/test_asdf.py
+++ b/daktari/test_asdf.py
@@ -1,0 +1,28 @@
+import unittest
+from daktari.asdf import get_tool_version_from_string
+
+class TestGetToolVersionFromString(unittest.TestCase):
+
+    def test_valid_tool(self):
+        content = """1password-cli 2.19.0
+cloud-sql-proxy 2.6.1
+# Comment line
+daktari 0.0.140"""
+        self.assertEqual(get_tool_version_from_string("1password-cli", content), "2.19.0")
+
+    def test_tool_with_comment(self):
+        content = """1password-cli 2.19.0 # also update in .daktari.py
+cloud-sql-proxy 2.6.1"""
+        self.assertEqual(get_tool_version_from_string("1password-cli", content), "2.19.0")
+
+    def test_tool_not_present(self):
+        content = """1password-cli 2.19.0
+cloud-sql-proxy 2.6.1"""
+        self.assertIsNone(get_tool_version_from_string("invalid-tool", content))
+
+    def test_empty_content(self):
+        content = ""
+        self.assertIsNone(get_tool_version_from_string("1password-cli", content))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
To use in `.daktari.py` files, so we don't have to specify versions in both Daktari and `.tool-versions`