### PR TITLE
[EE-571] Support later versions of direnv by checking for 0 status

### DIFF
--- a/daktari/checks/direnv.py
+++ b/daktari/checks/direnv.py
@@ -54,6 +54,6 @@ class DirenvAllowed(Check):
         if direnv_status is None:
             return self.failed("direnv status returned no output")
         cwd = getcwd()
-        query = f"Found RC path {cwd}/.envrc\n.*\n.*\nFound RC allowed (true|0)"
+        query = f"Found RC path {cwd}/.envrc(\n.*)*Found RC allowed (true|0)"
         direnv_allowed = re.search(query, direnv_status) is not None
         return self.verify(direnv_allowed, f"{cwd} is <not/> allowed to use direnv")

--- a/daktari/checks/direnv.py
+++ b/daktari/checks/direnv.py
@@ -54,6 +54,6 @@ class DirenvAllowed(Check):
         if direnv_status is None:
             return self.failed("direnv status returned no output")
         cwd = getcwd()
-        query = f"Found RC path {cwd}/.envrc\n.*\n.*\nFound RC allowed true"
+        query = f"Found RC path {cwd}/.envrc\n.*\n.*\nFound RC allowed (true|0)"
         direnv_allowed = re.search(query, direnv_status) is not None
         return self.verify(direnv_allowed, f"{cwd} is <not/> allowed to use direnv")


### PR DESCRIPTION
Later versions of direnv report a line of `Found RC allowed 0` rather than `Found RC allowed true`

This still feels a bit brittle, but couldn't see another way to do it