### PR TITLE
rosetta installed check

### DIFF
--- a/daktari/checks/mac.py
+++ b/daktari/checks/mac.py
@@ -1,0 +1,14 @@
+from daktari.command_utils import get_stdout
+
+class RosettaInstalled(Check):
+    name = "rosetta.installed"
+
+    suggestions = {
+        OS.OS_X: "<cmd>softwareupdate --install-rosetta</cmd>",
+        OS.GENERIC: "Error: Only required on MacOS",
+    }
+
+    def check(self) -> CheckResult:
+        # internally Rosetta is called OAH, `pgrep oahd` prints a number to stdout if Rosetta is installed
+        return self.verify(get_stdout("pgrep oahd") != "", "Rosetta is <not/> installed")
+


### PR DESCRIPTION
Turns out it's not totally trivial to find if rosetta is installed, there's a handful of ways to check listed [here](https://apple.stackexchange.com/questions/427970/how-to-tell-if-m1-mac-has-rosetta-installed), I've just picked one that seemed simple.

Not sure if we have any other platform-specific or architecture-specific checks, guessing we'll want to tweak this to only run on MacOS on Apple silicon

Also turns out there isn't a simple way to uninstall rosetta for testing. Guess we'll need to test the check in a VM?