### PR TITLE
Add check for Rosetta 2

### DIFF
--- a/daktari/check.py
+++ b/daktari/check.py
@@ -47,12 +47,12 @@ class Check:
     def passed_with_warning(self, message: str) -> CheckResult:
         return CheckResult(self.name, CheckStatus.PASS_WITH_WARNING, message, self.suggestions)
 
-    def verify(self, passed: bool, dual_message: str) -> CheckResult:
+    def verify(self, passed: bool, dual_message: str, failed_message: Optional[str] = None) -> CheckResult:
         pattern = re.compile(" <not/> ")
         if passed:
             return self.passed(pattern.sub(" ", dual_message))
         else:
-            return self.failed(pattern.sub(" not ", dual_message))
+            return self.failed(failed_message or pattern.sub(" not ", dual_message))
 
     def validate_semver_expression(
         self,

--- a/daktari/checks/misc.py
+++ b/daktari/checks/misc.py
@@ -8,6 +8,7 @@ from tabulate import tabulate
 from daktari.check import Check, CheckResult
 from daktari.os import OS, check_env_var_exists, get_env_var_value
 from daktari.version_utils import get_simple_cli_version
+from daktari.command_utils import can_run_command
 
 
 class WatchmanInstalled(Check):
@@ -288,3 +289,14 @@ class TaskInstalled(Check):
 
     def check(self) -> CheckResult:
         return self.verify_install("task")
+
+
+class Rosetta2Installed(Check):
+    name = "rosetta2.installed"
+    run_on = OS.OS_X
+    suggestions = {OS.OS_X: "<cmd>softwareupdate --install-rosetta</cmd>"}
+
+    def check(self) -> CheckResult:
+        return self.verify(
+            can_run_command("arch -x86_64 true"), "Rosetta 2 is installed or not required", "Rosetta 2 is not installed"
+        )


### PR DESCRIPTION
Uses `arch -x86_64 true`, which returns an exit code of 0 when Rosetta 2 is installed or when running on an Intel Mac where it is not required, or 1 if running on an ARM Mac without Rosetta 2.

I tested this by running the check on a fresh macOS 14 ARM VM (without and with Rosetta 2 installed), an Intel macOS 13 machine, and an Ubuntu VM.