### PR TITLE
Fix bug with 1Password account check and add unit tests, renames

### DIFF
--- a/daktari/checks/test_onepassword.py
+++ b/daktari/checks/test_onepassword.py
@@ -1,0 +1,12 @@
+import unittest
+
+from daktari.checks.onepassword import account_exists
+
+
+class TestOnePassword(unittest.TestCase):
+
+    def test_account_exists(self):
+        self.assertTrue(account_exists("checks/test_resources/op_config_with_account.json", "account-name"))
+        self.assertFalse(
+            account_exists("checks/test_resources/op_config_with_account.json", "non-existent-account-name")
+        )

--- a/daktari/checks/test_resources/op_config_with_account.json
+++ b/daktari/checks/test_resources/op_config_with_account.json
@@ -1,0 +1,16 @@
+{
+  "latest_signin": "account-name",
+  "device": "6CACE0AB-FD1A-45F9-B867-BB2D9F761B0C",
+  "accounts": [
+    {
+      "shorthand": "account-name",
+      "accountUUID": "0CB7E2C7-479B-4530-AD0E-2D45A295BD17",
+      "url": "https://account-name.1password.com",
+      "email": "joe.blogs@account-name.co",
+      "accountKey": "N-O-P-Q-R-N-O-P-Q-R-N-O-P-Q-R-N-O-P-Q-R-N-O-P-Q-R",
+      "userUUID": "D6067FE0-C616-413D-ACA5-0A58C5616CCD",
+      "dsecret": "N-O-P-Q-R-N-O-P-Q-R-N-O-P-Q-R-N-O-P-Q-R-N-O-P-Q-R"
+    }
+  ],
+  "system_auth_latest_signin": "1E28E218-DD55-4984-B22C-D31CBE7887B4"
+}

--- a/daktari/checks/test_resources/op_config_without_accounts.json
+++ b/daktari/checks/test_resources/op_config_without_accounts.json
@@ -1,0 +1,6 @@
+{
+  "latest_signin": "",
+  "device": "6CACE0AB-FD1A-45F9-B867-BB2D9F761B0C",
+  "accounts": null,
+  "system_auth_latest_signin": "1E28E218-DD55-4984-B22C-D31CBE7887B4"
+}


### PR DESCRIPTION
There was a bug in the check where `accounts` can be `null` in the OP config file. Also renamed checks to be a bit more consistent, and added tests.