### PR TITLE
Update intellij check to detect installations via toolbox

### DIFF
--- a/daktari/checks/intellij_idea.py
+++ b/daktari/checks/intellij_idea.py
@@ -128,7 +128,11 @@ def get_intellij_idea_version() -> Optional[VersionInfo]:
     if os == OS.OS_X:
         return get_intellij_idea_version_mac()
     elif os == OS.UBUNTU:
-        return get_intellij_idea_version_snap() or get_intellij_idea_version_tarball() or get_intellij_idea_toolbox_version()
+        return (
+            get_intellij_idea_version_snap()
+            or get_intellij_idea_version_tarball()
+            or get_intellij_idea_toolbox_version()
+        )
     else:
         return get_intellij_idea_version_tarball() or get_intellij_idea_toolbox_version()
 

--- a/daktari/checks/test_intellij_idea.py
+++ b/daktari/checks/test_intellij_idea.py
@@ -1,10 +1,17 @@
 import unittest
 
+from semver import VersionInfo
+
 from daktari.check import CheckStatus
-from daktari.checks.intellij_idea import IntelliJProjectSdkJavaVersion
+from daktari.checks.intellij_idea import IntelliJProjectSdkJavaVersion, get_intellij_version_from_product_info
 
 
 class TestIntellijIdea(unittest.TestCase):
+    def test_parse_product_info(self):
+        product_info_path = "checks/test_resources/intellij-product-info.json"
+        result = get_intellij_version_from_product_info(product_info_path)
+        self.assertEqual(result, VersionInfo(2023, 3, 5))
+
     def test_project_sdk_unset(self):
         check = IntelliJProjectSdkJavaVersion(17)
         check.file_path = "checks/test_resources/intellij_misc_no_sdk.xml"

--- a/daktari/checks/test_resources/intellij-product-info.json
+++ b/daktari/checks/test_resources/intellij-product-info.json
@@ -1,0 +1,25 @@
+{
+  "name": "IntelliJ IDEA",
+  "version": "2023.3.5",
+  "buildNumber": "233.14808.21",
+  "productCode": "IU",
+  "dataDirectoryName": "IntelliJIdea2023.3",
+  "svgIconPath": "bin/idea.svg",
+  "productVendor": "JetBrains",
+  "launch": [
+    {
+      "os": "Linux",
+      "arch": "amd64",
+      "launcherPath": "bin/idea.sh",
+      "javaExecutablePath": "jbr/bin/java",
+      "vmOptionsFilePath": "bin/idea64.vmoptions",
+      "startupWmClass": "jetbrains-idea",
+      "bootClassPathJarNames": [],
+      "additionalJvmArguments": [],
+      "mainClass": "com.intellij.idea.Main"
+    }
+  ],
+  "bundledPlugins": [],
+  "modules": [],
+  "fileExtensions": []
+}


### PR DESCRIPTION
Hi friends <3 

Updates the "IntelliJ installed" check to account for installations via [toolbox](https://www.jetbrains.com/lp/toolbox/), which seems to be JetBrains' recommended way these days. 

`which idea` gives e.g. `/home/alyssa/.local/share/JetBrains/Toolbox/scripts/idea` - from there you can go to the apps directory and dig out `product-info.json` like with a direct tarball install. Added a bonus test for parsing this with a trimmed down version of my real file :smile: 