### PR TITLE
Commit signing tweaks

### DIFF
--- a/daktari/checks/git.py
+++ b/daktari/checks/git.py
@@ -156,7 +156,6 @@ class GpgInstalled(Check):
 
 class GitCommitSigningSetUp(Check):
     name = "git.commitSigningSetUp"
-    depends_on = [GpgInstalled]
 
     suggestions = {
         OS.OS_X: "Follow instructions to set up commit signing: "
@@ -179,5 +178,21 @@ class GitCommitAutoSigningEnabled(Check):
 
     def check(self) -> CheckResult:
         setting = get_stdout("git config commit.gpgsign")
-        passed = setting is not None and setting.rstrip() == "true"
+        passed = setting == "true"
         return self.verify(passed, "commit.gpgsign is <not/> enabled")
+
+
+class GitCommitSigningFormat(Check):
+    name = "git.commitSigningFormat"
+
+    def __init__(self, required_format: str, suggestion: str):
+        self.required_format = required_format
+        self.suggestions = {OS.GENERIC: suggestion}
+
+    def check(self) -> CheckResult:
+        format_setting = get_stdout("git config gpg.format")
+        return self.verify(
+            format_setting == self.required_format,
+            f"gpg.format is {self.required_format}",
+            f"gpg.format is not {self.required_format}: {format_setting}"
+        )

--- a/daktari/checks/intellij_idea.py
+++ b/daktari/checks/intellij_idea.py
@@ -12,7 +12,7 @@ from semver import VersionInfo
 from daktari.check import Check, CheckResult
 from daktari.checks.files import FilesExist
 from daktari.checks.xml import XmlFileXPathCheck
-from daktari.command_utils import CommandErrorException, run_command
+from daktari.command_utils import get_stdout
 from daktari.os import OS, detect_os
 from daktari.version_utils import try_parse_semver, sanitise_version_string
 
@@ -77,10 +77,8 @@ def get_intellij_idea_version_snap() -> Optional[VersionInfo]:
 
 
 def get_intellij_idea_version_tarball() -> Optional[VersionInfo]:
-    try:
-        idea_bin_path = run_command(["sh", "-c", "which idea.sh"]).stdout.rstrip("\n")
-    except CommandErrorException:
-        logging.debug("Could not locate idea.sh", exc_info=True)
+    idea_bin_path = get_stdout(["sh", "-c", "which idea.sh"])
+    if idea_bin_path is None:
         return None
 
     product_info_path = os.path.join(os.path.dirname(idea_bin_path), "..", "product-info.json")
@@ -88,10 +86,8 @@ def get_intellij_idea_version_tarball() -> Optional[VersionInfo]:
 
 
 def get_intellij_idea_toolbox_version() -> Optional[VersionInfo]:
-    try:
-        idea_bin_path = run_command(["sh", "-c", "which idea"]).stdout.rstrip("\n")
-    except CommandErrorException:
-        logging.debug("Could not locate idea", exc_info=True)
+    idea_bin_path = get_stdout(["sh", "-c", "which idea"])
+    if idea_bin_path is None:
         return None
 
     apps_dir = os.path.join(os.path.dirname(idea_bin_path), "..", "apps")

--- a/daktari/command_utils.py
+++ b/daktari/command_utils.py
@@ -64,7 +64,8 @@ def can_run_command(command) -> bool:
 
 def get_stdout(command) -> Optional[str]:
     try:
-        return run_command(command).stdout
+        result = run_command(command).stdout
+        return result.rstrip() if result is not None else result
     except Exception:
         logging.debug("Exception running command", exc_info=True)
         return None


### PR DESCRIPTION
In this PR:

 - Remove dependency on `GpgInstalled` from other commit signing checks - commit signing can be done via SSH which doesn't require GPG to be installed.
 - Add a check for `gpg.format` 
 - Tweak `get_stdout` to automatically `rstrip`, and tidy up some places that were doing that themselves