### PR TITLE
`.warn_only()` override

### DIFF
--- a/daktari/check.py
+++ b/daktari/check.py
@@ -32,7 +32,7 @@ class Check:
     suggestions: Dict[str, str] = {}
     run_on: Optional[str] = None
     skip: bool = False
-    warn_on_failure: bool = False
+    warn_only_on_failure: bool = False
 
     def with_dependencies(self, *dependencies: Type["Check"]) -> "Check":
         copy = deepcopy(self)
@@ -43,7 +43,7 @@ class Check:
         return CheckResult(self.name, CheckStatus.PASS, message, self.suggestions)
 
     def failed(self, message: str) -> CheckResult:
-        status = CheckStatus.PASS_WITH_WARNING if self.warn_on_failure else CheckStatus.FAIL
+        status = CheckStatus.PASS_WITH_WARNING if self.warn_only_on_failure else CheckStatus.FAIL
         return CheckResult(self.name, status, message, self.suggestions)
 
     def passed_with_warning(self, message: str) -> CheckResult:
@@ -111,7 +111,7 @@ class Check:
         return self
 
     def warn_only(self) -> "Check":
-        self.warn_on_failure = True
+        self.warn_only_on_failure = True
         return self
 
     def should_run(self, current_os: str) -> bool:

--- a/daktari/check.py
+++ b/daktari/check.py
@@ -32,6 +32,7 @@ class Check:
     suggestions: Dict[str, str] = {}
     run_on: Optional[str] = None
     skip: bool = False
+    warn_on_failure: bool = False
 
     def with_dependencies(self, *dependencies: Type["Check"]) -> "Check":
         copy = deepcopy(self)
@@ -42,7 +43,8 @@ class Check:
         return CheckResult(self.name, CheckStatus.PASS, message, self.suggestions)
 
     def failed(self, message: str) -> CheckResult:
-        return CheckResult(self.name, CheckStatus.FAIL, message, self.suggestions)
+        status = CheckStatus.PASS_WITH_WARNING if self.warn_on_failure else CheckStatus.FAIL
+        return CheckResult(self.name, status, message, self.suggestions)
 
     def passed_with_warning(self, message: str) -> CheckResult:
         return CheckResult(self.name, CheckStatus.PASS_WITH_WARNING, message, self.suggestions)
@@ -106,6 +108,10 @@ class Check:
 
     def skip_if(self, condition: bool) -> "Check":
         self.skip = condition
+        return self
+
+    def warn_only(self) -> "Check":
+        self.warn_on_failure = True
         return self
 
     def should_run(self, current_os: str) -> bool:

--- a/daktari/test_check.py
+++ b/daktari/test_check.py
@@ -72,5 +72,10 @@ class TestConfig(unittest.TestCase):
         self.assertTrue(DummyCheck().skip_if(False).should_run(OS.GENERIC))
         self.assertFalse(DummyCheck().skip_if(True).should_run(OS.GENERIC))
 
+    def test_warn_only(self):
+        check = DummyCheck(succeed=False).warn_only()
+        result = check.check()
+        self._verify_result(result, CheckStatus.PASS_WITH_WARNING, "dummy check")
+
     def _verify_result(self, result: CheckResult, expected_status: CheckStatus, expected_message: str):
         self.assertEqual(result, CheckResult("check.name", expected_status, expected_message, {}))


### PR DESCRIPTION
So you can include out-the-box checks but demote to a warning where perhaps they're more guidance than a hard rule. 