### PR TITLE
tolerate non-strict semver in IntelliJ version parsing

### DIFF
--- a/daktari/checks/intellij_idea.py
+++ b/daktari/checks/intellij_idea.py
@@ -48,7 +48,7 @@ def get_intellij_idea_version_mac() -> Optional[VersionInfo]:
         version_str = sanitise_version_string(version_str)
         version = try_parse_semver(version_str)
 
-        logging.debug(f"IntelliJ IDEA version (via NSBundle): {version}")
+        logging.debug(f"IntelliJ IDEA version (via NSBundle): {version} ({version_str})")
         return version
 
 

--- a/daktari/test_config.py
+++ b/daktari/test_config.py
@@ -138,8 +138,9 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(expected_contents, actual_contents)
 
     def test_version_number_sanitised(self):
-        result = sanitise_version_string("9.22")
-        self.assertEqual("9.22.0", result)
+        self.assertEqual(sanitise_version_string("9.22"), "9.22.0")
+        self.assertEqual(sanitise_version_string("1.2.3"), "1.2.3")
+        self.assertEqual(sanitise_version_string("1.2.3.4"), "1.2.3")
 
     def test_local_config_template(self):
         template_text = get_resource(LOCAL_CONFIG_TEMPLATE)

--- a/daktari/version_utils.py
+++ b/daktari/version_utils.py
@@ -27,5 +27,11 @@ def try_parse_semver(version_str: Optional[str]) -> Optional[VersionInfo]:
         return None
 
 
+# Coerce version strings into a standard semver format: major.minor.patch
 def sanitise_version_string(version_str: str) -> str:
-    return version_str + ".0" if version_str.count(".") == 1 else version_str
+    parts = version_str.split(".")
+    if len(parts) == 2:
+        return version_str + ".0"
+    elif len(parts) >= 4:
+        return ".".join(parts[:3])
+    return version_str


### PR DESCRIPTION
Current version of IJ is 2024.3.1.1 which doesn't get parsed correctly as 3-part semver - leading to the Daktari check erroneously diagnosing IJ as not installed. Simplest fix I think is to adjust our fudging function `sanitise_version_string` to coerce it to 3-part semver (but it is a bit ad-hoc and ugly!)