### PR TITLE
following symlinks can allow misleading results from os.stat

### DIFF
--- a/daktari/checks/files.py
+++ b/daktari/checks/files.py
@@ -47,7 +47,8 @@ class DirExists(DirsExist):
 class FilesOwnedByUser(Check):
     name = "files.ownedByUser"
 
-    def __init__(self, file_paths: List[str], expected_owner: str = "root", pass_fail_message: str = "", follow_symlinks: bool = False):
+    def __init__(self, file_paths: List[str], expected_owner: str = "root", pass_fail_message: str = "",
+                 follow_symlinks: bool = False):
         self.file_paths = file_paths
         self.expected_owner = expected_owner
         file_paths_str = ", ".join(file_paths)

--- a/daktari/checks/files.py
+++ b/daktari/checks/files.py
@@ -47,8 +47,13 @@ class DirExists(DirsExist):
 class FilesOwnedByUser(Check):
     name = "files.ownedByUser"
 
-    def __init__(self, file_paths: List[str], expected_owner: str = "root", pass_fail_message: str = "",
-                 follow_symlinks: bool = False):
+    def __init__(
+        self,
+        file_paths: List[str],
+        expected_owner: str = "root",
+        pass_fail_message: str = "",
+        follow_symlinks: bool = False,
+    ):
         self.file_paths = file_paths
         self.expected_owner = expected_owner
         file_paths_str = ", ".join(file_paths)

--- a/daktari/checks/files.py
+++ b/daktari/checks/files.py
@@ -47,17 +47,18 @@ class DirExists(DirsExist):
 class FilesOwnedByUser(Check):
     name = "files.ownedByUser"
 
-    def __init__(self, file_paths: List[str], expected_owner: str = "root", pass_fail_message: str = ""):
+    def __init__(self, file_paths: List[str], expected_owner: str = "root", pass_fail_message: str = "", follow_symlinks: bool = False):
         self.file_paths = file_paths
         self.expected_owner = expected_owner
         file_paths_str = ", ".join(file_paths)
         self.pass_fail_message = pass_fail_message or f"{file_paths_str} are <not/> owned by {expected_owner}"
+        self.follow_symlinks = follow_symlinks
 
     def check(self) -> CheckResult:
         for file_path in self.file_paths:
             expanded_file_path = expanduser(file_path)
             if file_exists(expanded_file_path):
-                if get_file_owner(expanded_file_path) != self.expected_owner:
+                if get_file_owner(expanded_file_path, self.follow_symlinks) != self.expected_owner:
                     return self.verify(False, self.pass_fail_message)
             else:
                 return self.failed(f"{expanded_file_path} is not present")

--- a/daktari/file_utils.py
+++ b/daktari/file_utils.py
@@ -47,6 +47,6 @@ def dir_exists(path: str) -> bool:
     return testing_dir.is_dir()
 
 
-def get_file_owner(file_path: str) -> str:
-    file_stat = os.stat(file_path, follow_symlinks=False)
+def get_file_owner(file_path: str, follow_symlinks: bool = False) -> str:
+    file_stat = os.stat(file_path, follow_symlinks=follow_symlinks)
     return getpwuid(file_stat.st_uid).pw_name

--- a/daktari/file_utils.py
+++ b/daktari/file_utils.py
@@ -48,5 +48,5 @@ def dir_exists(path: str) -> bool:
 
 
 def get_file_owner(file_path: str) -> str:
-    file_stat = os.stat(file_path)
+    file_stat = os.stat(file_path, follow_symlinks=False)
     return getpwuid(file_stat.st_uid).pw_name


### PR DESCRIPTION
### **User description**
I think it makes sense not to follow symlinks here because we generally don't care who owns a system file?


___

### **PR Type**
Bug fix


___

### **Description**
- Updated `os.stat` call to not follow symlinks.

- Prevented misleading results when determining file ownership.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_utils.py</strong><dd><code>Prevent symlink following in `get_file_owner` function</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

daktari/file_utils.py

<li>Modified <code>os.stat</code> call to include <code>follow_symlinks=False</code>.<br> <li> Ensured accurate file ownership retrieval by not following symlinks.


</details>


  </td>
  <td><a href="https://github.com/glean-notes/daktari/pull/339/files#diff-6e745893c90f57f6e8262da92a3721aa2f8c983cb25fe373dd9de516b564c07e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information