### PR TITLE
/etc/hosts formatting check

### DIFF
--- a/daktari/checks/etc_hosts.py
+++ b/daktari/checks/etc_hosts.py
@@ -1,7 +1,8 @@
 from daktari.check import Check, CheckResult
 from daktari.os import OS
 
-
+# We found that if /etc/hosts used a mixture of tabs and spaces it caused some applications to ignore /etc/hosts and perform DNS lookups instead.
+# This check enforces a single space in any blankspace in /etc/hosts.
 class EtcHostsFormattedCorrectly(Check):
     name = "etc.hosts.formattedCorrectly"
     description = "Check if /etc/hosts is formatted correctly with consistent use of tabs and spaces"

--- a/daktari/checks/etc_hosts.py
+++ b/daktari/checks/etc_hosts.py
@@ -1,0 +1,21 @@
+from daktari.check import Check, CheckResult
+from daktari.os import OS
+
+
+class EtcHostsFormattedCorrectly(Check):
+    name = "etc.hosts.formattedCorrectly"
+    description = "Check if /etc/hosts is formatted correctly with consistent use of tabs and spaces"
+
+    def __init__(self):
+        self.suggestions = {
+            OS.GENERIC: "Reformat /etc/hosts to use a single space consistently in blankspace:\n\n" + r"<cmd>sudo sed -Ei 's:( |\t)+: :g' /etc/hosts</cmd>",
+        }
+
+    def check(self) -> CheckResult:
+        with open("/etc/hosts", "r") as f:
+            content = f.read()
+            if "\t" in content or "  " in content:
+                return self.failed("/etc/hosts is usess tabs or multiple spaces in blankspace.")
+            else:
+                return self.passed("/etc/hosts is formatted correctly")
+

--- a/daktari/checks/misc.py
+++ b/daktari/checks/misc.py
@@ -3,7 +3,6 @@ from os.path import expanduser
 from typing import Dict, Optional
 
 from python_hosts import Hosts
-from tabulate import tabulate
 
 from daktari.check import Check, CheckResult
 from daktari.os import OS, check_env_var_exists, get_env_var_value
@@ -193,7 +192,7 @@ class HostAliasesConfigured(Check):
     def __init__(self, required_aliases: Dict[str, str]):
         self.required_aliases = required_aliases
         hosts_path = Hosts.determine_hosts_path()
-        entries_text = tabulate([(addr, name) for (name, addr) in self.required_aliases.items()], tablefmt="plain")
+        entries_text = "\n".join([f"{addr} {name}" for (name, addr) in self.required_aliases.items()])
         self.suggestions = {OS.GENERIC: f"Add the following entries to {hosts_path}:\n\n{entries_text}"}
 
     def check(self) -> CheckResult:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ requests==2.32.3
 responses==0.25.7
 semver==3.0.4
 python-hosts==1.0.7
-tabulate==0.9.0
-types-tabulate==0.9.0.20241207
 PyYAML==6.0.2
 types-PyYAML==6.0.12.20250516
 pyobjc-core==11.0; sys_platform == 'darwin'


### PR DESCRIPTION
We found that if /etc/hosts used a mixture of tabs and spaces it caused some applications to ignore /etc/hosts and perform DNS lookups instead.
This check enforces a single space in any blankspace in /etc/hosts.

This also updates our suggestion for adding to /etc/hosts to use a single space rather than double space as you get with "tabulate"