### PR TITLE
Fixing sed command on mac

### DIFF
--- a/daktari/checks/etc_hosts.py
+++ b/daktari/checks/etc_hosts.py
@@ -15,7 +15,7 @@ class EtcHostsFormattedCorrectly(Check):
             OS.OS_X: "Reformat /etc/hosts to use a single space consistently in blankspace:\n\n"
             + r"<cmd>sudo sed -Ei '' 's:( |\t)+: :g' /etc/hosts</cmd>",
             OS.UBUNTU: "Reformat /etc/hosts to use a single space consistently in blankspace:\n\n"
-            + r"<cmd>sudo sed -Ei 's:( |\t)+: :g' /etc/hosts</cmd>"
+            + r"<cmd>sudo sed -Ei 's:( |\t)+: :g' /etc/hosts</cmd>",
         }
 
     def check(self) -> CheckResult:

--- a/daktari/checks/etc_hosts.py
+++ b/daktari/checks/etc_hosts.py
@@ -12,8 +12,10 @@ class EtcHostsFormattedCorrectly(Check):
 
     def __init__(self):
         self.suggestions = {
-            OS.GENERIC: "Reformat /etc/hosts to use a single space consistently in blankspace:\n\n"
-            + r"<cmd>sudo sed -Ei 's:( |\t)+: :g' /etc/hosts</cmd>",
+            OS.OS_X: "Reformat /etc/hosts to use a single space consistently in blankspace:\n\n"
+            + r"<cmd>sudo sed -Ei '' 's:( |\t)+: :g' /etc/hosts</cmd>",
+            OS.UBUNTU: "Reformat /etc/hosts to use a single space consistently in blankspace:\n\n"
+            + r"<cmd>sudo sed -Ei 's:( |\t)+: :g' /etc/hosts</cmd>"
         }
 
     def check(self) -> CheckResult:


### PR DESCRIPTION
### **User description**
Sed on mac wants a file extension for the backup file. We don't care in this case. Linux doesn't care about that and so can use the original command.


___

### **PR Type**
bug_fix


___

### **Description**
- Fixes `sed` command for macOS compatibility in /etc/hosts suggestion.

- Adds OS-specific suggestions for reformatting /etc/hosts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>etc_hosts.py</strong><dd><code>Fix and clarify sed command for OS-specific /etc/hosts formatting</code></dd></summary>
<hr>

daktari/checks/etc_hosts.py

<li>Updates sed command for macOS to include required empty backup <br>extension.<br> <li> Adds OS-specific keys (OS.OS_X and OS.UBUNTU) for /etc/hosts <br>reformatting suggestions.<br> <li> Removes generic OS suggestion in favor of explicit OS-specific ones.


</details>


  </td>
  <td><a href="https://github.com/glean-notes/daktari/pull/375/files#diff-ec4b57029b38f0dbeb6478af00d08a3f5514f51bb427a8b10b4f1be32e1fb776">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>