### PR TITLE
Fix preCommit.gitHooksInstalled false negative in git worktrees

### DIFF
--- a/daktari/checks/git.py
+++ b/daktari/checks/git.py
@@ -133,7 +133,10 @@ class PreCommitGitHooksInstalled(Check):
     }
 
     def check(self) -> CheckResult:
-        git_hooks_installed = file_contains_text(".git/hooks/pre-commit", "pre-commit.com")
+        # Ask git for the hook path rather than assuming ".git/hooks/pre-commit": this honours
+        # core.hooksPath and resolves correctly inside worktrees (where ".git" is a file).
+        hook_path = get_stdout("git rev-parse --git-path hooks/pre-commit")
+        git_hooks_installed = hook_path is not None and file_contains_text(hook_path, "pre-commit.com")
         return self.verify(git_hooks_installed, "pre-commit Git hooks are <not/> installed")
 
 

--- a/daktari/checks/git.py
+++ b/daktari/checks/git.py
@@ -133,8 +133,6 @@ class PreCommitGitHooksInstalled(Check):
     }
 
     def check(self) -> CheckResult:
-        # Ask git for the hook path rather than assuming ".git/hooks/pre-commit": this honours
-        # core.hooksPath and resolves correctly inside worktrees (where ".git" is a file).
         hook_path = get_stdout("git rev-parse --git-path hooks/pre-commit")
         git_hooks_installed = hook_path is not None and file_contains_text(hook_path, "pre-commit.com")
         return self.verify(git_hooks_installed, "pre-commit Git hooks are <not/> installed")

--- a/daktari/test_git.py
+++ b/daktari/test_git.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch
+
+from daktari.check import CheckStatus
+from daktari.checks.git import PreCommitGitHooksInstalled
+
+# The path git resolves the pre-commit hook to. In a worktree this is *not*
+# ".git/hooks/pre-commit" (there ".git" is a file, not a directory), and when
+# core.hooksPath is set it points outside the per-worktree gitdir entirely.
+RESOLVED_HOOK_PATH = "/main/.git/hooks/pre-commit"
+LITERAL_HOOK_PATH = ".git/hooks/pre-commit"
+
+
+def fake_hook_contents(path: str, text: str) -> bool:
+    """Model a worktree: only the git-resolved hook path exists and is installed.
+
+    The literal ".git/hooks/pre-commit" path is absent (in a worktree ".git" is a
+    file), so reading it directly always misses.
+    """
+    return path == RESOLVED_HOOK_PATH and text == "pre-commit.com"
+
+
+class TestPreCommitGitHooksInstalled(unittest.TestCase):
+    @patch("daktari.checks.git.file_contains_text", side_effect=fake_hook_contents)
+    @patch("daktari.checks.git.get_stdout", return_value=RESOLVED_HOOK_PATH)
+    def test_passes_in_worktree_when_hook_resolves_via_git(self, mock_get_stdout, mock_contains):
+        result = PreCommitGitHooksInstalled().check()
+        self.assertEqual(
+            result.status,
+            CheckStatus.PASS,
+            "Hooks are installed (resolved via git), so the check should pass even in a worktree",
+        )
+        mock_get_stdout.assert_called_once_with("git rev-parse --git-path hooks/pre-commit")
+
+    @patch("daktari.checks.git.file_contains_text", side_effect=fake_hook_contents)
+    @patch("daktari.checks.git.get_stdout", return_value=RESOLVED_HOOK_PATH)
+    def test_resolved_path_is_checked_not_literal(self, mock_get_stdout, mock_contains):
+        PreCommitGitHooksInstalled().check()
+        mock_contains.assert_called_once_with(RESOLVED_HOOK_PATH, "pre-commit.com")
+
+    @patch("daktari.checks.git.file_contains_text", return_value=False)
+    @patch("daktari.checks.git.get_stdout", return_value=RESOLVED_HOOK_PATH)
+    def test_fails_when_hook_not_installed(self, mock_get_stdout, mock_contains):
+        result = PreCommitGitHooksInstalled().check()
+        self.assertEqual(result.status, CheckStatus.FAIL)
+
+    @patch("daktari.checks.git.file_contains_text", return_value=False)
+    @patch("daktari.checks.git.get_stdout", return_value=None)
+    def test_fails_gracefully_when_git_cannot_resolve_path(self, mock_get_stdout, mock_contains):
+        result = PreCommitGitHooksInstalled().check()
+        self.assertEqual(result.status, CheckStatus.FAIL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`PreCommitGitHooksInstalled` reported ❌ `preCommit.gitHooksInstalled` when daktari ran **inside a git worktree**, even though pre-commit hooks were genuinely installed and active.

The check hardcoded a literal, cwd-relative path:

```python
file_contains_text(".git/hooks/pre-commit", "pre-commit.com")
```

Two compounding reasons this is wrong:

1. **Worktrees** — in a worktree, `.git` is a *file* (`gitdir: .../worktrees/<name>`), not a directory, so `.git/hooks/pre-commit` doesn't resolve at all → `file_contains_text` returns `False`.
2. **`core.hooksPath`** — when set (as in the Genio monorepo, pointing at the main repo's common hooks dir), the real hook lives outside the per-worktree gitdir. The literal path never sees it.

`git rev-parse --git-path hooks/pre-commit` resolves both correctly — it honours `core.hooksPath` and the worktree gitdir indirection.

### Evidence (reproduced in a real monorepo worktree)

```
.git is a FILE -> gitdir: /Users/.../genio/.git/worktrees/<name>
test -f .git/hooks/pre-commit            -> DOES NOT EXIST  (check FAILS)
git rev-parse --git-path hooks/pre-commit -> /Users/.../genio/.git/hooks/pre-commit
  -> EXISTS and contains "pre-commit.com" (hooks ARE installed)
```

## Fix

Resolve the hook path via git instead of assuming it:

```python
hook_path = get_stdout("git rev-parse --git-path hooks/pre-commit")
git_hooks_installed = hook_path is not None and file_contains_text(hook_path, "pre-commit.com")
```

`get_stdout` was already imported and `rstrip()`s its output / returns `None` on failure, so no extra handling is needed.

## Tests

New `daktari/test_git.py` (test-first — the worktree cases failed before the fix, pass after):

- `test_passes_in_worktree_when_hook_resolves_via_git` — literal path absent, git-resolved path installed → PASS
- `test_resolved_path_is_checked_not_literal` — asserts the resolved path is what's read
- `test_fails_when_hook_not_installed` — genuine not-installed → FAIL
- `test_fails_gracefully_when_git_cannot_resolve_path` — `get_stdout` returns `None` → FAIL

## Verification

| Check | Result |
|---|---|
| New tests post-fix | 4/4 pass |
| Patched check in a real worktree (no mocks) | returns PASS (was FAIL) |
| Full suite | 124 → 128 tests, no new failures |
| black / flake8 / mypy | clean |

Note: the suite has 8 pre-existing failures + 1 error (`test_onepassword`, `test_intellij_idea`, `test_ssh`), confirmed unrelated — identical with this change stashed.

Scope is isolated: a source sweep confirmed `PreCommitGitHooksInstalled` is the only check that reads a `.git/` path directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)