### PR TITLE
Fix HostAliasesConfigured false-negative on dual-stack hostnames

### DIFF
--- a/daktari/checks/misc.py
+++ b/daktari/checks/misc.py
@@ -1,6 +1,6 @@
 import logging
 from os.path import expanduser
-from typing import Dict, Optional
+from typing import Dict, Optional, Set
 
 from python_hosts import Hosts
 
@@ -189,9 +189,10 @@ class Md5SumInstalled(Check):
 class HostAliasesConfigured(Check):
     name = "hostAliases.configured"
 
-    def __init__(self, required_aliases: Dict[str, str]):
+    def __init__(self, required_aliases: Dict[str, str], hosts_path: Optional[str] = None):
         self.required_aliases = required_aliases
-        hosts_path = Hosts.determine_hosts_path()
+        self.hosts_path = hosts_path
+        hosts_path = hosts_path or Hosts.determine_hosts_path()
 
         aliases_by_addr: Dict[str, list[str]] = {}
 
@@ -209,15 +210,18 @@ class HostAliasesConfigured(Check):
         self.suggestions = {OS.GENERIC: suggestion_text}
 
     def check(self) -> CheckResult:
-        hosts = Hosts()
+        hosts = Hosts(path=self.hosts_path)
         entries = [e for e in hosts.entries if e.entry_type in ("ipv4", "ipv6")]
-        entries_dict = {}
+        # A hostname can legitimately map to several addresses (e.g. dual-stack
+        # localhost -> both 127.0.0.1 and ::1), so collect all addresses per name
+        # rather than letting the last entry in file order win.
+        entries_dict: Dict[str, Set[str]] = {}
         for entry in entries:
             for name in entry.names:
-                entries_dict[name] = entry.address
+                entries_dict.setdefault(name, set()).add(entry.address)
         logging.debug(f"Hosts file entries: {entries_dict}")
         for name, address in self.required_aliases.items():
-            if entries_dict.get(name) != address:
+            if address not in entries_dict.get(name, set()):
                 return self.failed(f"{hosts.path} alias {name} -> {address} not present")
 
         return self.passed(f"{hosts.path} aliases present")

--- a/daktari/checks/test_misc.py
+++ b/daktari/checks/test_misc.py
@@ -1,16 +1,51 @@
+import os
+import tempfile
 import unittest
 
 from daktari.check import CheckStatus
 from daktari.checks.misc import HostAliasesConfigured
 
+# Stock macOS /etc/hosts maps "localhost" to both 127.0.0.1 and ::1, with the
+# ::1 line appearing last. The check must treat the IPv4 alias as satisfied
+# regardless of the order the two lines appear in (see HostAliasesConfigured).
+DUAL_STACK_IPV6_LAST = "127.0.0.1 localhost\n255.255.255.255 broadcasthost\n::1 localhost\n"
+DUAL_STACK_IPV4_LAST = "::1 localhost\n255.255.255.255 broadcasthost\n127.0.0.1 localhost\n"
+
 
 class TestHostAliasesConfigured(unittest.TestCase):
+    def _hosts_fixture(self, content):
+        f = tempfile.NamedTemporaryFile("w", suffix=".hosts", delete=False)
+        f.write(content)
+        f.close()
+        self.addCleanup(os.unlink, f.name)
+        return f.name
+
     def test_checking_hosts_does_not_blow_up_on_success(self):
         result = HostAliasesConfigured({}).check()
         self.assertEqual(result.status, CheckStatus.PASS)
 
     def test_checking_hosts_does_not_blow_up_on_failure(self):
         result = HostAliasesConfigured({"host": "no.such.entry.surely"}).check()
+        self.assertEqual(result.status, CheckStatus.FAIL)
+
+    def test_dual_stack_alias_passes_with_ipv6_entry_last(self):
+        path = self._hosts_fixture(DUAL_STACK_IPV6_LAST)
+        result = HostAliasesConfigured({"localhost": "127.0.0.1"}, hosts_path=path).check()
+        self.assertEqual(result.status, CheckStatus.PASS)
+
+    def test_dual_stack_alias_passes_with_ipv4_entry_last(self):
+        path = self._hosts_fixture(DUAL_STACK_IPV4_LAST)
+        result = HostAliasesConfigured({"localhost": "127.0.0.1"}, hosts_path=path).check()
+        self.assertEqual(result.status, CheckStatus.PASS)
+
+    def test_dual_stack_ipv6_alias_also_satisfied(self):
+        path = self._hosts_fixture(DUAL_STACK_IPV6_LAST)
+        result = HostAliasesConfigured({"localhost": "::1"}, hosts_path=path).check()
+        self.assertEqual(result.status, CheckStatus.PASS)
+
+    def test_missing_alias_still_fails(self):
+        path = self._hosts_fixture(DUAL_STACK_IPV6_LAST)
+        result = HostAliasesConfigured({"localhost": "10.0.0.1"}, hosts_path=path).check()
         self.assertEqual(result.status, CheckStatus.FAIL)
 
 


### PR DESCRIPTION
## Problem

`HostAliasesConfigured.check()` flattened `/etc/hosts` into a single `name -> address` dict by iterating all IPv4/IPv6 entries in file order and assigning `entries_dict[name] = entry.address` — **last write wins**. Any hostname that legitimately has both an IPv4 and IPv6 entry kept only its last address.

The canonical case is `localhost`: a stock macOS `/etc/hosts` contains both `127.0.0.1 localhost` and `::1 localhost`, with the `::1` line last. The check recorded `localhost -> ::1` and then failed a required `localhost -> 127.0.0.1` alias with "alias localhost -> 127.0.0.1 not present" — even though localhost resolves to 127.0.0.1 for IPv4 fine.

The outcome was **purely ordering-dependent**: machines whose `127.0.0.1 localhost` line happens to come last passed; machines with the default macOS ordering failed. This is the source of the long-standing cross-developer flip-flopping on this check. The bug has been present since v0.0.100.

## Fix

Collect **all** addresses per name into a `set` and treat a required `name -> address` as satisfied if the address appears among them:

```python
entries_dict: Dict[str, Set[str]] = {}
for entry in entries:
    for name in entry.names:
        entries_dict.setdefault(name, set()).add(entry.address)
...
if address not in entries_dict.get(name, set()):
    return self.failed(...)
```

Order-independent, and correctly handles dual-stack hostnames.

Also adds an optional `hosts_path` parameter so the check can run against fixtures.

## Tests

Added regression tests covering both orderings of a dual-stack `localhost`, the IPv6 alias, and a genuine miss. Written test-first — they fail on the old logic (specifically the macOS-default ordering) and pass with the fix.

Verified against the real macOS `/etc/hosts` (`127.0.0.1 localhost` then `::1 localhost`): old logic FAILs, new logic PASSes.

## Downstream note

The genio repo pins daktari `0.0.314`, which carries the identical bug. Once this merges and CI publishes, that pin (and the nix flake) should move to the fixed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)