### PR TITLE
Add Nix flake for distributing daktari

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -8,7 +8,7 @@ jobs:
   flake:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v30
         with:
           extra_nix_config: |

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,21 @@
+name: Nix flake
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  flake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Check flake
+        run: nix flake check --print-build-logs
+      - name: Build daktari
+        run: nix build .#daktari --print-build-logs
+      - name: Run daktari against CI config
+        run: ./result/bin/daktari --debug --config .ci-config.py

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,7 @@ cython_debug/
 .direnv/
 
 .DS_Store
+
+# Nix build symlinks
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,98 @@
+{
+  description = "Daktari - assist in setting up and maintaining developer environments";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self, nixpkgs, flake-utils }:
+    let
+      # Single source of truth: read the version from the same file the
+      # automated release (bumpversion) rewrites. There is no second place to
+      # update, so the flake's version always matches the source it builds.
+      version = (builtins.fromTOML (builtins.readFile ./pyproject.toml)).project.version;
+
+      mkDaktari =
+        pkgs:
+        let
+          inherit (pkgs) lib stdenv;
+          py = pkgs.python3.pkgs;
+        in
+        py.buildPythonApplication {
+          pname = "daktari";
+          inherit version;
+          pyproject = true;
+
+          # Use the flake's own source tree. No fetchFromGitHub and no src hash
+          # to maintain - the consumer's flake.lock pins the revision for us.
+          src = self;
+
+          build-system = [ py.setuptools ];
+
+          # requirements.txt pins exact versions (==); use nixpkgs' versions
+          # instead of trying to match those pins.
+          pythonRelaxDeps = true;
+
+          dependencies =
+            with py;
+            [
+              ansicolors
+              distro
+              pyfiglet
+              importlib-resources
+              packaging
+              setuptools
+              requests
+              responses
+              semver
+              python-hosts
+              pyyaml
+              types-pyyaml
+              requests-unixsocket
+              dpath
+              pyopenssl
+              types-pyopenssl
+              pyclip
+              urllib3
+            ]
+            ++ lib.optionals stdenv.hostPlatform.isDarwin [
+              pyobjc-core
+              pyobjc-framework-Cocoa
+            ];
+
+          # Tests are colocated with the source and expect to run with the
+          # daktari/ working directory (see CLAUDE.md); they are not part of
+          # the packaged build. Validate the install via an import instead.
+          doCheck = false;
+          pythonImportsCheck = [ "daktari" ];
+
+          meta = {
+            description = "Assist in setting up and maintaining developer environments";
+            homepage = "https://github.com/genio-learn/daktari";
+            license = lib.licenses.mit;
+            mainProgram = "daktari";
+          };
+        };
+    in
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        daktari = mkDaktari pkgs;
+      in
+      {
+        packages.default = daktari;
+        packages.daktari = daktari;
+        apps.default = flake-utils.lib.mkApp { drv = daktari; };
+      }
+    )
+    // {
+      # System-independent overlay so the genio flake can pull daktari in as
+      # `pkgs.daktari` after adding this flake as an input.
+      overlays.default = final: _prev: {
+        daktari = mkDaktari final;
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,6 @@
 
           build-system = [ py.setuptools ];
 
-          # Use nixpkgs' versions rather than the == pins in requirements.txt.
           pythonRelaxDeps = true;
 
           dependencies =

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,7 @@
   outputs =
     { self, nixpkgs, flake-utils }:
     let
-      # Single source of truth: read the version from the same file the
-      # automated release (bumpversion) rewrites. There is no second place to
-      # update, so the flake's version always matches the source it builds.
+      # Read from the file bumpversion already rewrites; no version to hand-sync.
       version = (builtins.fromTOML (builtins.readFile ./pyproject.toml)).project.version;
 
       mkDaktari =
@@ -25,14 +23,12 @@
           inherit version;
           pyproject = true;
 
-          # Use the flake's own source tree. No fetchFromGitHub and no src hash
-          # to maintain - the consumer's flake.lock pins the revision for us.
+          # No src hash to maintain; the consumer's flake.lock pins the revision.
           src = self;
 
           build-system = [ py.setuptools ];
 
-          # requirements.txt pins exact versions (==); use nixpkgs' versions
-          # instead of trying to match those pins.
+          # Use nixpkgs' versions rather than the == pins in requirements.txt.
           pythonRelaxDeps = true;
 
           dependencies =
@@ -62,9 +58,7 @@
               pyobjc-framework-Cocoa
             ];
 
-          # Tests are colocated with the source and expect to run with the
-          # daktari/ working directory (see CLAUDE.md); they are not part of
-          # the packaged build. Validate the install via an import instead.
+          # Tests need the daktari/ working directory; not run as part of packaging.
           doCheck = false;
           pythonImportsCheck = [ "daktari" ];
 
@@ -89,8 +83,6 @@
       }
     )
     // {
-      # System-independent overlay so the genio flake can pull daktari in as
-      # `pkgs.daktari` after adding this flake as an input.
       overlays.default = final: _prev: {
         daktari = mkDaktari final;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,6 @@
   outputs =
     { self, nixpkgs, flake-utils }:
     let
-      # Read from the file bumpversion already rewrites; no version to hand-sync.
       version = (builtins.fromTOML (builtins.readFile ./pyproject.toml)).project.version;
 
       mkDaktari =

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,6 @@
           inherit version;
           pyproject = true;
 
-          # No src hash to maintain; the consumer's flake.lock pins the revision.
           src = self;
 
           build-system = [ py.setuptools ];

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,6 @@
               pyfiglet
               importlib-resources
               packaging
-              setuptools
               requests
               responses
               semver
@@ -63,6 +62,7 @@
           meta = {
             description = "Assist in setting up and maintaining developer environments";
             homepage = "https://github.com/genio-learn/daktari";
+            changelog = "https://github.com/genio-learn/daktari/releases/tag/v${version}";
             license = lib.licenses.mit;
             mainProgram = "daktari";
           };

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,6 @@
               pyobjc-framework-Cocoa
             ];
 
-          # Tests need the daktari/ working directory; not run as part of packaging.
           doCheck = false;
           pythonImportsCheck = [ "daktari" ];
 


### PR DESCRIPTION
## What

Adds a `flake.nix` so Nix consumers (the genio repo) can pull daktari straight from a git tag, instead of waiting for it to land in nixpkgs.

## Versioning — correct by construction

The flake is **self-referencing**: it lives in this repo and packages it.

- **Version** is read from `pyproject.toml` (`builtins.fromTOML`) — the same file the automated bumpversion release already rewrites. There is no version string to hand-edit.
- **Source** is `src = self` (the flake's own tree), so there is no `fetchFromGitHub` and **no `src` hash to maintain** — the consumer's `flake.lock` pins the revision.

Net result: when the release workflow bumps the version and tags `v0.0.x`, the flake at that tag automatically reports `0.0.x`. There is no second place to update.

## Outputs

- `packages.{default,daktari}` — the `buildPythonApplication`
- `apps.default` — so `nix run github:genio-learn/daktari` works
- `overlays.default` — so the genio flake can use `pkgs.daktari`

## Consuming it

```nix
inputs.daktari.url = "github:genio-learn/daktari/v0.0.333";  # pin a release
# or: "github:genio-learn/daktari";                          # track latest
```

## Verification

- `nix build .#daktari` → exit 0; all deps (incl. darwin-only pyobjc) resolve from cache.nixos.org.
- `./result/bin/daktari --version` → `daktari 0.0.333`.
- `pythonRelaxDeps = true` lets nixpkgs' versions satisfy the `==` pins in `requirements.txt`; the runtime-deps check still passes.

## Notes

- `responses` + `types-*` are test/mypy-only but are listed in `requirements.txt`, so they're included to keep the runtime-deps check honest rather than disabling it.
- `flake.lock` pins nixpkgs `nixos-unstable`; daktari's build deps only move on `nix flake update` here, while daktari's own releases flow through immediately.
- Possible follow-up: a `nix flake check` step in CI to catch a broken flake before genio pulls a new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)